### PR TITLE
Avoid eager resolve-spec on unq schema

### DIFF
--- a/src/main/clojure/clojure/alpha/spec/impl.clj
+++ b/src/main/clojure/clojure/alpha/spec/impl.clj
@@ -414,7 +414,7 @@
         ks (filter keyword? coll)
         qks (zipmap ks ks)
         unq-map (apply merge (filter map? coll))
-        unq-specs (map s/resolve-spec (vals unq-map))
+        unq-specs (map #(if (qualified-keyword? %) % (s/resolve-spec %)) (vals unq-map))
         uqks (zipmap (keys unq-map) unq-specs)
         key-specs (merge uqks qks)
         lookup #(or (s/get-spec %) (get key-specs %))]


### PR DESCRIPTION
Preserve metadata at the beginning of the spec chain rather than resolving to the end in the case of unqualified schemas, so the behavior is now equivalent for qualified and unqualified versions of the same schema (similar to the `s/keys` behavior).